### PR TITLE
#24 Feature Request: Add Support for File Services

### DIFF
--- a/src/hydrusvideodeduplicator/__main__.py
+++ b/src/hydrusvideodeduplicator/__main__.py
@@ -120,7 +120,7 @@ def main(
         else:
             error_connecting_exception_msg = "Failed to connect to Hydrus. Is your Hydrus instance running?"
         error_connecting_exception = exc
-    except hydrus_api.HydrusAPIException as exc:
+    except KeyError as exc:
         # Probably a file_service_key error
         error_connecting_exception_msg = str(exc)
         error_connecting_exception = exc

--- a/src/hydrusvideodeduplicator/config.py
+++ b/src/hydrusvideodeduplicator/config.py
@@ -24,9 +24,6 @@ if in_wsl():
 
 HYDRUS_API_URL = os.getenv("HYDRUS_API_URL", f"https://{_DEFAULT_IP}:{_DEFAULT_PORT}")
 
-# Service key of specific local file service to fetch files from
-HYDRUS_LOCAL_FILE_SERVICE_KEY = os.getenv("HYDRUS_LOCAL_FILE_SERVICE_KEY")
-
 # ~/.local/share/hydrusvideodeduplicator/ on Linux
 DEDUP_DATABASE_DIR = AppDirs("hydrusvideodeduplicator").user_data_dir
 DEDUP_DATABASE_DIR = os.getenv("DEDUP_DATABASE_DIR", DEDUP_DATABASE_DIR)
@@ -44,4 +41,16 @@ if HYDRUS_QUERY is not None:
     except json.decoder.JSONDecodeError as exc:
         print("ERROR:", exc)
         print("Invalid query passed as environment variable.")
+        exit(-1)
+
+# Service key of specific local file service to fetch files from
+HYDRUS_LOCAL_FILE_SERVICE_KEYS = os.getenv("HYDRUS_LOCAL_FILE_SERVICE_KEYS")
+if HYDRUS_LOCAL_FILE_SERVICE_KEYS is not None:
+    try:
+        HYDRUS_LOCAL_FILE_SERVICE_KEYS = json.loads(HYDRUS_LOCAL_FILE_SERVICE_KEYS)
+        if not isinstance(HYDRUS_LOCAL_FILE_SERVICE_KEYS, list):
+            raise Exception('Decoded JSON is not a list')
+    except Exception as exc:
+        print("Error:", exc)
+        print("Invalid list of file service keys passed as environment variable. Must be in JSON list format")
         exit(-1)

--- a/src/hydrusvideodeduplicator/config.py
+++ b/src/hydrusvideodeduplicator/config.py
@@ -27,6 +27,9 @@ HYDRUS_API_URL = os.getenv("HYDRUS_API_URL", f"https://{_DEFAULT_IP}:{_DEFAULT_P
 # Service name of where to store perceptual hash tag for video files
 HYDRUS_LOCAL_TAG_SERVICE_NAME = os.getenv("HYDRUS_LOCAL_TAG_SERVICE_NAME", "my tags")
 
+# Service key of specific local file service to fetch files from
+HYDRUS_LOCAL_FILE_SERVICE_KEY = os.getenv("HYDRUS_LOCAL_FILE_SERVICE_KEY", "my tags")
+
 # ~/.local/share/hydrusvideodeduplicator/ on Linux
 DEDUP_DATABASE_DIR = AppDirs("hydrusvideodeduplicator").user_data_dir
 DEDUP_DATABASE_DIR = os.getenv("DEDUP_DATABASE_DIR", DEDUP_DATABASE_DIR)

--- a/src/hydrusvideodeduplicator/dedup.py
+++ b/src/hydrusvideodeduplicator/dedup.py
@@ -28,7 +28,7 @@ class HydrusVideoDeduplicator:
     _DEBUG = False
 
     def __init__(
-        self, client: hydrus_api.Client, verify_connection: bool = True, file_service_keys: Iterable[str] | None = None
+        self, client: hydrus_api.Client, verify_connection: bool = True, file_service_keys: List[str] | None = None
     ):
         self.client = client
         if verify_connection:

--- a/src/hydrusvideodeduplicator/dedup.py
+++ b/src/hydrusvideodeduplicator/dedup.py
@@ -42,9 +42,9 @@ class HydrusVideoDeduplicator:
         # Set the file service keys to be used for hashing
         # Default is "all local files"
         if file_service_keys is None:
-            self.file_service_key = self.all_services["all_local_files"][0]["service_key"]
+            self.file_service_keys = [self.all_services["all_local_files"][0]["service_key"]]
         else:
-            self.verify_file_service_key(file_service_keys)
+            self.verify_file_service_keys(file_service_keys)
             self.file_service_keys = file_service_keys
 
     # Verify client connection and permissions
@@ -56,7 +56,7 @@ class HydrusVideoDeduplicator:
         hydrus_api.utils.verify_permissions(self.client, hydrus_api.utils.Permission)
 
     # Verify that the supplied file_service_key is a valid key for a local file service
-    def verify_file_service_key(self, file_service_keys: Iterable[str]) -> None:
+    def verify_file_service_keys(self, file_service_keys: Iterable[str]) -> None:
         VALID_SERVICE_TYPES = [hydrus_api.ServiceType.ALL_LOCAL_FILES, hydrus_api.ServiceType.FILE_DOMAIN]
 
         for file_service_key in file_service_keys:


### PR DESCRIPTION
Noticed that the dupe finder was always targeting 'all local files', so I took a crack at adding a basic new CLI option for targeting a specific file service.

Most context can be found in issue #24 

@appleappleapplenanner I'm not married to any of this, and it's been a hot sec since I wrote serious Python code, so more than happy to make changes both functional and stylistic if there's anything you want to see differently. Also no rush to review this! It's is running well on my local machine, so I'm in no hurry.