### PR TITLE
Deleted Files Check Progress Bar

### DIFF
--- a/src/hydrusvideodeduplicator/dedup.py
+++ b/src/hydrusvideodeduplicator/dedup.py
@@ -140,7 +140,6 @@ class HydrusVideoDeduplicator:
             dbsize = os.path.getsize(DEDUP_DATABASE_FILE)
 
             if dblen > 0:
-                rprint(f"[blue] Database found with {dblen} videos already hashed.")
                 self.hydlog.info(f"Database found of length {dblen}, size {dbsize} bytes")
             else:
                 self.hydlog.info(f"Database not found. Creating one at {DEDUP_DATABASE_FILE}")
@@ -373,6 +372,7 @@ class HydrusVideoDeduplicator:
             delete_count = 0
             with SqliteDict(str(DEDUP_DATABASE_FILE), tablename="videos", flag="c") as hashdb:
                 total = len(hashdb)
+                rprint(f"[blue] Database found with {total} videos already hashed.")
                 with tqdm(dynamic_ncols=True, total=total, desc="Checking for trashed files in cache",
                           unit="files", colour="BLUE") as pbar:
                     for batched_keys in self.batched(hashdb, CHUNK_SIZE):

--- a/src/hydrusvideodeduplicator/dedup.py
+++ b/src/hydrusvideodeduplicator/dedup.py
@@ -372,9 +372,13 @@ class HydrusVideoDeduplicator:
             delete_count = 0
             with SqliteDict(str(DEDUP_DATABASE_FILE), tablename="videos", flag="c") as hashdb:
                 total = len(hashdb)
+
+                if total < 1:
+                    return
+
                 rprint(f"[blue] Database found with {total} videos already hashed.")
-                with tqdm(dynamic_ncols=True, total=total, desc="Checking for trashed files in cache",
-                          unit="files", colour="BLUE") as pbar:
+                with tqdm(dynamic_ncols=True, total=total, desc="Checking for trashed videos in cache",
+                          unit="videos", colour="BLUE") as pbar:
                     for batched_keys in self.batched(hashdb, CHUNK_SIZE):
                         is_trashed_result = self.is_files_trashed_hydrus(batched_keys)
                         for result in is_trashed_result.items():
@@ -383,6 +387,6 @@ class HydrusVideoDeduplicator:
                                 delete_count += 1
                         hashdb.commit()
                         pbar.update(len(batched_keys))
-            self.hydlog.info(f"Cleared {delete_count} trashed files from the database.")
+            self.hydlog.info(f"Cleared {delete_count} trashed videos from the database.")
         except OSError:
-            rprint("[red] Error while clearing trashed files cache.")
+            rprint("[red] Error while clearing trashed videos cache.")


### PR DESCRIPTION
Adding a progress bar to the "checking for deleted files in cache" process, since that can actually take a while on large caches, and currently it just looks like the program is hanging/doing nothing while it's running that.

Example w/ new progress bar:
![image](https://github.com/hydrusvideodeduplicator/hydrus-video-deduplicator/assets/65079055/0ab60766-7b92-469c-9331-d9ba0ee8cf0d)
