### PR TITLE
Potential Duplicates Queue

### DIFF
--- a/src/hydrusvideodeduplicator/config.py
+++ b/src/hydrusvideodeduplicator/config.py
@@ -58,7 +58,13 @@ DEDUP_DATABASE_DIR = Path(_DEDUP_DATABASE_DIR_ENV)
 _DEDUP_DATABASE_NAME_ENV = os.getenv("DEDUP_DATABASE_NAME", "videohashes")
 DEDUP_DATABASE_FILE = Path(DEDUP_DATABASE_DIR, f"{_DEDUP_DATABASE_NAME_ENV}.sqlite")
 
+_PDQ_DATABASE_NAME = os.getenv("DEDUP_DATABASE_NAME", "pdq")
+PDQ_DATABASE_FILE = Path(DEDUP_DATABASE_DIR, f"{_PDQ_DATABASE_NAME}.sqlite")
+PDQ_TABLE_NAME = "potential_duplicates_queue"
+
 REQUESTS_CA_BUNDLE = os.getenv("REQUESTS_CA_BUNDLE")
+
+QUEUE_RELATIONSHIP_API_CALLS = True if os.getenv("QUEUE_RELATIONSHIP_API_CALLS") else False
 
 # Optional query for selecting files to process
 _HYDRUS_QUERY_ENV = os.getenv("HYDRUS_QUERY")

--- a/src/hydrusvideodeduplicator/dedup_util.py
+++ b/src/hydrusvideodeduplicator/dedup_util.py
@@ -6,8 +6,11 @@ import contextlib
 from pathlib import Path
 from sqlitedict import SqliteDict
 from rich import print as rprint
+from tqdm import tqdm
 
 from hydrusvideodeduplicator.hydrus_api import Client
+
+from .config import DEDUP_DATABASE_FILE
 
 
 # Given a lexicographically SORTED list of tags, find the tag given a namespace
@@ -162,3 +165,15 @@ def database_accessible(db_file: Path | str, tablename: str, verbose: bool = Fal
             rprint(f"[red] Could not access database.")
         logging.error(str(exc))
     return False
+
+
+def get_pd_table_key(hash_a: str, hash_b: str):
+    if hash_a > hash_b:
+        return hash(hash(hash_a) + hash(hash_b))
+    elif hash_a < hash_b:
+        return hash(hash(hash_b) + hash(hash_a))
+    else:
+        raise Exception(
+            f"hash_a is the same as hash_b, which means we're comparing a file with itself - something's not "
+            f"right here."
+        )


### PR DESCRIPTION
Here's a rough draft of the work I did to enable 'queueing' found potential duplicates, rather than sending them to the client API every time one is found. I've tested it out and it's all working pretty well, but the code isn't necessarily in "final draft" form. Definitely open to change suggestions