### PR TITLE
Bugfix: Avoid Cleared Files Causing Skipped Dupe Searches

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For more information check out the [wiki](https://github.com/hydrusvideodeduplic
 
 ---
 
-## Installation:
+## [Installation:](https://github.com/hydrusvideodeduplicator/hydrus-video-deduplicator/wiki/Installation)
 #### Dependencies:
 - Python >=3.10
 - FFmpeg

--- a/src/hydrusvideodeduplicator/dedup.py
+++ b/src/hydrusvideodeduplicator/dedup.py
@@ -329,7 +329,7 @@ class HydrusVideoDeduplicator:
                                                     f"'farthest_search_index' of {farthest_search_index} for db size " +
                                                     f"of {total}. Please report error.")
                                 elif farthest_search_index == len(hashdb):
-                                    # This is not necessary but may increase speed by avoiding any of the code below
+                                    # This file has already been searched for dupes against all other videos in the DB
                                     continue
 
                                 parallel(

--- a/src/hydrusvideodeduplicator/dedup.py
+++ b/src/hydrusvideodeduplicator/dedup.py
@@ -256,13 +256,14 @@ class HydrusVideoDeduplicator:
                     for batched_keys in HydrusVideoDeduplicator.batched(hashdb, CHUNK_SIZE):
                         for key in batched_keys:
                             row = hashdb[key]
-                            if row['farthest_search_index'] > new_total:
+                            if 'farthest_search_index' in row and row['farthest_search_index'] > new_total:
                                 row['farthest_search_index'] = new_total
+                                hashdb[key] = row
                         hashdb.commit()
                         pbar.update(len(batched_keys))
         except Exception as exc:
             rprint(f"[red] Error encountered when updating search indices:\n{str(exc)}")
-            rprint("[red] Warning: uplicate search for this run may not be fully complete.")
+            rprint("[red] Warning: duplicate search for this run may not be fully complete.")
 
     # Sliding window duplicate comparisons
     # Alternatively, I could scan duplicates when added and never do it again which would be one of the best ways without a VP tree
@@ -435,7 +436,7 @@ class HydrusVideoDeduplicator:
                         self.update_search_cache()
                     else:
                         rprint(f"[green] Found no trashed videos to delete from the database.")
-                    rprint(f"[green] There are now {len(hashdb)} videos now the database.")
+                    rprint(f"[green] There are {len(hashdb)} videos now the database.")
 
         except OSError as exc:
             rprint("[red] Error accessing database. Skipping clearing of trashed videos")

--- a/src/hydrusvideodeduplicator/dedup.py
+++ b/src/hydrusvideodeduplicator/dedup.py
@@ -250,21 +250,13 @@ class HydrusVideoDeduplicator:
             with SqliteDict(str(DEDUP_DATABASE_FILE), tablename="videos", flag="c", outer_stack=False) as hashdb:
                 if new_total is None:
                     new_total = len(hashdb)
-                with tqdm(
-                        dynamic_ncols=True,
-                        total=new_total,
-                        desc="Updating video search indices",
-                        unit="video",
-                        colour="BLUE",
-                ) as pbar:
-                    for batched_keys in HydrusVideoDeduplicator.batched(hashdb, CHUNK_SIZE):
-                        for key in batched_keys:
-                            row = hashdb[key]
-                            if 'farthest_search_index' in row and row['farthest_search_index'] > new_total:
-                                row['farthest_search_index'] = new_total
-                                hashdb[key] = row
-                        hashdb.commit()
-                        pbar.update(len(batched_keys))
+                for batched_keys in HydrusVideoDeduplicator.batched(hashdb, CHUNK_SIZE):
+                    for key in batched_keys:
+                        row = hashdb[key]
+                        if 'farthest_search_index' in row and row['farthest_search_index'] > new_total:
+                            row['farthest_search_index'] = new_total
+                            hashdb[key] = row
+                    hashdb.commit()
         except Exception as exc:
             rprint(f"[red] Error encountered when updating search indices:\n{str(exc)}")
             rprint("[red] Warning: duplicate search for this run may not be fully complete.")


### PR DESCRIPTION
If files are cleared from a database that's already been previously searched, the `farthest_search_index` of each file in the database becomes out-of-date, which can lead to a wide variety of errors, including old files not being searched for duplicates against new files.

The primary work in this code is to make sure that the `farthest_search_index` is updated whenever files are cleared from the DB. Additional updates have been made to what's printed out by the program, related to this process, to improve general clarity of output.

NOTE: I highly recommend viewing the file changes with the "hide whitespace changes" enabled - it makes for a cleaner viewing experience, particularly in `clear_trashed_files_from_db()` where most of the changes are just tab indentations.