### PR TITLE
Bugfix: HVD not working with Hydrus v539 and above

### DIFF
--- a/src/hydrusvideodeduplicator/dedup.py
+++ b/src/hydrusvideodeduplicator/dedup.py
@@ -97,7 +97,7 @@ class HydrusVideoDeduplicator:
         # Add perceptual hashes to video files
         # system:filetype tags are really inconsistent
         search_tags = [
-            'system:filetype=video, gif, apng',
+            'system:filetype=video, animated gif, apng',
             'system:has duration',
             'system:file service is not currently in trash',
         ]


### PR DESCRIPTION
Resolves bug https://github.com/hydrusvideodeduplicator/hydrus-video-deduplicator/issues/36

Note, this patch will render HVD incompatible with Hydrus versions earlier than v539.