### PR TITLE
Add option to add failed videos to Hydrus page

### DIFF
--- a/src/hydrusvideodeduplicator/__main__.py
+++ b/src/hydrusvideodeduplicator/__main__.py
@@ -14,6 +14,7 @@ from .config import (
     HYDRUS_LOCAL_FILE_SERVICE_KEYS,
     HYDRUS_QUERY,
     REQUESTS_CA_BUNDLE,
+    FAILED_PAGE_NAME,
 )
 from .db import DedupeDB
 from .dedup import HydrusVideoDeduplicator
@@ -51,7 +52,12 @@ def main(
     clear_search_cache: Annotated[
         Optional[bool], typer.Option(help="Clear the cache that tracks what files have already been compared")
     ] = False,
-    job_count: Annotated[Optional[int], typer.Option(help="Number of CPUs to use. Default is all but one core.")] = -2,
+    failed_page_name: Annotated[
+        Optional[str], typer.Option(help="The name of the Hydrus page to add failed files to.")
+    ] = FAILED_PAGE_NAME,
+    job_count: Annotated[
+        Optional[int], typer.Option(help="Number of CPU threads to use. Default is all but one core.")
+    ] = -2,
     verbose: Annotated[Optional[bool], typer.Option(help="Verbose logging")] = False,
     debug: Annotated[Optional[bool], typer.Option(hidden=True)] = False,
 ):
@@ -59,7 +65,7 @@ def main(
     assert overwrite is not None and threshold is not None and skip_hashing is not None and job_count is not None
 
     # CLI debug parameter sets log level to info or debug
-    loglevel = logging.WARNING
+    loglevel = logging.INFO
     if debug:
         loglevel = logging.DEBUG
         verbose = True
@@ -140,10 +146,7 @@ def main(
 
     # Deduplication
 
-    deduper = HydrusVideoDeduplicator(
-        client=hvdclient,
-        job_count=job_count,
-    )
+    deduper = HydrusVideoDeduplicator(client=hvdclient, job_count=job_count, failed_page_name=failed_page_name)
 
     if debug:
         deduper.hydlog.setLevel(logging.DEBUG)

--- a/src/hydrusvideodeduplicator/config.py
+++ b/src/hydrusvideodeduplicator/config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 from pathlib import Path
@@ -57,6 +59,8 @@ DEDUP_DATABASE_DIR = Path(_DEDUP_DATABASE_DIR_ENV)
 
 _DEDUP_DATABASE_NAME_ENV = os.getenv("DEDUP_DATABASE_NAME", "videohashes")
 DEDUP_DATABASE_FILE = Path(DEDUP_DATABASE_DIR, f"{_DEDUP_DATABASE_NAME_ENV}.sqlite")
+
+FAILED_PAGE_NAME = os.getenv("FAILED_PAGE_NAME", None)
 
 REQUESTS_CA_BUNDLE = os.getenv("REQUESTS_CA_BUNDLE")
 

--- a/src/hydrusvideodeduplicator/dedup_util.py
+++ b/src/hydrusvideodeduplicator/dedup_util.py
@@ -10,6 +10,8 @@ if TYPE_CHECKING:
     from collections.abc import Generator, Iterable
     from typing import Any
 
+from rich import print
+
 
 def batched(iterable: Iterable, batch_size: int) -> Generator[tuple, Any, None]:
     """
@@ -87,3 +89,25 @@ def get_file_import_time(file_metadata: dict):
         except KeyError:
             continue
     raise KeyError
+
+
+# The logging level for logging e.g. CRITICAL or WARNING
+Severity = int
+
+
+def severity_to_color(severity: Severity) -> str:
+    if severity > logging.WARNING:
+        return "[red]"
+    elif severity == logging.WARNING:
+        return "[yellow]"
+    elif severity <= logging.INFO:
+        return ""  # No color
+    # No color
+    return ""
+
+
+def print_and_log(logger: logging.Logger, msg: str, severity: Severity = logging.INFO):
+    """Print to the user and log. Changes print color based on the severity."""
+    print(f"{severity_to_color(severity)} {logging._levelToName[severity]}")
+    print(f"{msg}\n")
+    logger.log(severity, msg)

--- a/src/hydrusvideodeduplicator/page_logger.py
+++ b/src/hydrusvideodeduplicator/page_logger.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+
+from .client import HVDClient
+from .dedup_util import print_and_log
+
+import logging
+
+
+def get_page_key(client: HVDClient, page_name: str) -> str | None:
+    """Takes the provided page name, and searches through all the pages in the Hydrus client for an appropriate
+    page with that name. If there are multiple pages with the same name, one of those pages is chosen randomly."""
+    response = client.client.get_pages()
+    page_key = find_page_key_from_name(response["pages"], page_name)
+    return page_key
+
+
+def find_page_key_from_name(page: dict[str, Any], page_name: str) -> str | None:
+    """Recursive function to search the response JSON provided by the Hydrus API's get_pages call. Because every
+    page can potentially contain other pages, a recursive search through the object is necessary. As soon as a
+    page is found with the correct page name and page type, that page's page_key is returned."""
+    if page["name"].lower() == page_name.lower() and page["page_type"] == 6:
+        return page["page_key"]
+    elif "pages" in page:
+        for subpage in page["pages"]:
+            result = find_page_key_from_name(subpage, page_name)
+            if result is not None:
+                return result
+    return None
+
+
+class HydrusPageLogger:
+    """Class to add files to pages in Hydrus."""
+
+    _log = logging.getLogger("HydrusPageLogger")
+    _log.setLevel(logging.INFO)
+
+    def __init__(self, client: HVDClient, page_name: str):
+        """Page name must exist in Hydrus or an error will occur."""
+        self.client = client
+        self.page_name = page_name
+
+    def add_failed_video(self, video_hash: str) -> None:
+        """Try to add a failed video to the Hydrus page."""
+        try:
+            page_key = get_page_key(self.client, self.page_name)
+            if page_key is None:
+                raise Exception("page_key is None.")
+        except Exception as e:
+            print_and_log(self._log, str(e), logging.ERROR)
+            print_and_log(self._log, f"Error when trying to get page key for page name {self.page_name}", logging.ERROR)
+            return None
+
+        try:
+            self.client.client.add_files_to_page(page_key=page_key, hashes=[video_hash])
+        except Exception as e:
+            print_and_log(self._log, str(e), logging.ERROR)
+            print_and_log(
+                self._log,
+                f"""Error when trying to add file: '{video_hash}' \
+                \nto client page: '{self.page_name}' \
+                \nwith page_key: '{page_key}' \
+                \nEnsure there is a page in Hydrus named '{self.page_name}' \
+                """,
+                logging.ERROR,
+            )


### PR DESCRIPTION
Add feature to add files that fail to hash to a Hydrus page to allow easy viewing of failed videos #15 

API cannot create pages currently, so the user needs to create a page manually and pass in the page name with the new CLI option.

A good amount of the work in this PR is by @prof-m  from PR #35.

Unrelated changes:

- Changed default log level from warning to info
- Updated comment about the unordered generator now that joblib finally added it 