### PR TITLE
Fix Dockerfile issue with global Python package install

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,33 @@
+# Test that the Dockerfile builds successfully.
+# This does not test that the newest Python changes work, since the package is installed from pypi.
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+    paths:
+      - Dockerfile
+      - docker-entrypoint.sh
+      - .github/workflows/build-docker.yml
+  pull_request:
+    branches:
+      - main
+      - develop
+    paths:
+      - Dockerfile
+      - docker-entrypoint.sh
+      - .github/workflows/build-docker.yml
+  workflow_dispatch:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          push: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,19 @@
-FROM ubuntu:latest
+FROM ubuntu:24.04
 WORKDIR /usr/src/app
 RUN apt-get update && apt-get install -y \
-    python3.11 \
+    python3 \
     python3-pip \
+    python3-venv \
     git \
     ffmpeg \
     && rm -rf /var/lib/apt/lists/*
-RUN python3.11 -m pip install hydrusvideodeduplicator
+
+# Need to make a venv because Ubuntu doesn't allow globally installed Python packages anymore (PEP 668)
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+RUN python -m pip install hydrusvideodeduplicator
 COPY ./docker-entrypoint.sh ./entrypoint.sh
 
 ENV DEDUP_DATABASE_DIR=/usr/src/app/db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
-version: "3.8"
+# Example compose file
 
 services:
   hydrusvideodeduplicator:
     build: .
     container_name: hydrusvideodeduplicator
     volumes:
-      - ./db:/usr/src/app/db # Database directory
+      - ./db:/usr/src/app/db          # Database directory
     # - <cert file>:/usr/src/app/cert # Optional, SSL cert
     environment:
       API_KEY: <your key>
@@ -15,6 +15,6 @@ services:
     # See full list of options on the wiki
 
     # If default API_URL does not connect to Hydrus on Docker host,
-    # try using host network mode and set API_URL to https://localhost:45869
-    #network_mode: host
+    # try using network_mode: host and set API_URL to https://localhost:45869
+    network_mode: host
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-Command="python3.11 -m hydrusvideodeduplicator"
+Command="python -m hydrusvideodeduplicator"
 [[ -n "${API_KEY}" ]] && Command="${Command} --api-key='${API_KEY}'"
 [[ -n "${API_URL}" ]] && Command="${Command} --api-url='${API_URL}'"
 [[ -n "${THRESHOLD}" ]] && Command="${Command} --threshold=${THRESHOLD}"


### PR DESCRIPTION
## Summary

Dockerfile doesn't build on ubuntu-latest (24.04) because it doesn't allow installing Python packages globally (PEP 668).

This PR fixes this and adds a few more improvements with the Dockerfile.

- Change Python version from python3.11 --> python3
  - 3.11 was installed explicitly instead of the default 3.10 for performance reasons. python 3.11 is the default on Ubuntu 24, so this is not necessary anymore.

- Pin Ubuntu version
  - If I don't test the Dockerfile for a while I still want the Dockerfile to work and not rely on ubuntu-latest working.
  
- Install Python packages with a venv

- Add GH action to test Dockerfile build